### PR TITLE
FASE 2: agente local de impresión Windows para LAI (sin dependencia del navegador)

### DIFF
--- a/lai/index.php
+++ b/lai/index.php
@@ -1,5 +1,6 @@
 <?php
 include 'conexion.php';
+include 'print_agent_config.php';
 
 
 session_start();
@@ -82,22 +83,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['producto'])) {
     // Imprimir tickets
     echo '<script>
         const tickets = ' . json_encode($tickets) . ';
-        function imprimirTickets(tickets, index = 0) {
-            if (index >= tickets.length) return;
-            const ticket = tickets[index];
-            const ventana = window.open(
-                "factura_tkt.php?producto=" + encodeURIComponent(ticket.producto) + "&precio=" + ticket.precio,
-                "_blank",
-                "width=200,height=100,top=1000,left=2000"
-            );
-            const checkClosed = setInterval(() => {
-                if (ventana.closed) {
-                    clearInterval(checkClosed);
-                    setTimeout(() => imprimirTickets(tickets, index + 1), 500);
-                }
-            }, 300);
+        window.__laiPendingPrintJobs = window.__laiPendingPrintJobs || [];
+        window.__laiPendingPrintJobs.push(tickets);
+        if (window.laiPrintTickets) {
+            window.laiPrintTickets(tickets);
         }
-        imprimirTickets(tickets);
     </script>';
 }
 
@@ -208,26 +198,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['registrar_venta'])) {
         // Imprimir tickets uno por uno
         echo '<script>
             var tickets = ' . json_encode($tickets) . ';
-            function imprimirTickets(tickets, index) {
-                if (index === undefined) index = 0;
-                if (index >= tickets.length) return;
-                var ticket = tickets[index];
-                var ventana = window.open(
-                    "factura_tkt.php?producto=" + encodeURIComponent(ticket.producto) + "&precio=" + ticket.precio,
-                    "_blank",
-                    "width=200,height=100,top=1000,left=2000"
-                );
-
-                var checkClosed = setInterval(function() {
-                    if (ventana.closed) {
-                        clearInterval(checkClosed);
-                        setTimeout(function() {
-                            imprimirTickets(tickets, index + 1);
-                        }, 500);
-                    }
-                }, 300);
+            window.__laiPendingPrintJobs = window.__laiPendingPrintJobs || [];
+            window.__laiPendingPrintJobs.push(tickets);
+            if (window.laiPrintTickets) {
+                window.laiPrintTickets(tickets);
             }
-            imprimirTickets(tickets);
         </script>';
 
     } else {
@@ -357,9 +332,103 @@ if ($result_usuario && $result_usuario->num_rows > 0) {
 
 		
         </div>
-		
-		
+
+
     </div>
+<script>
+  (function () {
+    const AGENT_ENABLED = <?php echo $PRINT_AGENT_ENABLED ? 'true' : 'false'; ?>;
+    const AGENT_URL = <?php echo json_encode($PRINT_AGENT_URL); ?>;
+    const AGENT_API_KEY = <?php echo json_encode($PRINT_AGENT_API_KEY); ?>;
+    const AGENT_DEFAULTS = <?php echo json_encode($PRINT_AGENT_DEFAULTS); ?>;
+    const USUARIO = <?php echo json_encode($usuario_nombre); ?>;
+    const HORA = <?php echo json_encode(date('d/m/Y H:i:s', strtotime('+21 hours'))); ?>;
+
+    function formatPrecio(precio) {
+      const numero = Number(precio || 0);
+      if (Number.isNaN(numero)) {
+        return '0';
+      }
+      return Math.round(numero).toLocaleString('es-AR');
+    }
+
+    function construirTicketTexto(ticket) {
+      const producto = String(ticket.producto || 'Producto');
+      const precio = formatPrecio(ticket.precio);
+      const lineas = [
+        '- JINETEADA LAI -',
+        'PARA RETIRAR',
+        '------------------------------',
+        HORA,
+        'Atendido por: ' + USUARIO,
+        '------------------------------',
+        'Producto:',
+        producto,
+        '------------------------------',
+        'Precio: $ ' + precio,
+        '------------------------------',
+        'Gracias por su compra'
+      ];
+      return lineas.join('\n');
+    }
+
+    async function enviarAlAgente(ticket) {
+      const payload = {
+        ticketText: construirTicketTexto(ticket),
+        printConfig: AGENT_DEFAULTS
+      };
+
+      const response = await fetch(AGENT_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-lai-api-key': AGENT_API_KEY
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        const detalle = await response.text();
+        throw new Error('Agente respondió ' + response.status + ' - ' + detalle);
+      }
+    }
+
+    function printFallback(ticket) {
+      window.open(
+        'factura_tkt.php?producto=' + encodeURIComponent(ticket.producto) + '&precio=' + ticket.precio,
+        '_blank',
+        'width=200,height=100,top=1000,left=2000'
+      );
+    }
+
+    window.laiPrintTicketsFallback = function (tickets) {
+      (tickets || []).forEach(printFallback);
+    };
+
+    window.laiPrintTickets = async function (tickets) {
+      const lista = tickets || [];
+      for (const ticket of lista) {
+        try {
+          if (AGENT_ENABLED) {
+            await enviarAlAgente(ticket);
+            continue;
+          }
+        } catch (error) {
+          console.warn('Error en agente local, se usa fallback', error);
+        }
+        printFallback(ticket);
+      }
+    };
+
+    const pendientes = window.__laiPendingPrintJobs || [];
+    if (pendientes.length > 0) {
+      window.__laiPendingPrintJobs = [];
+      pendientes.forEach(function (tickets) {
+        window.laiPrintTickets(tickets);
+      });
+    }
+  })();
+</script>
 </body>
 </html>
 

--- a/lai/local-print-agent-node/README.md
+++ b/lai/local-print-agent-node/README.md
@@ -1,0 +1,61 @@
+# LAI Local Print Agent (Windows)
+
+Agente local para desacoplar la impresión del navegador en `/lai/`.
+
+## Requisitos
+
+- Windows 10/11
+- Node.js 18+
+- PowerShell 5+
+- Impresora térmica instalada en Windows
+
+## Instalación rápida
+
+1. Copiar esta carpeta a la PC (por ejemplo `C:\lai-print-agent`).
+2. Crear `config.json` desde el ejemplo:
+   - `copy config.example.json config.json`
+3. Editar `config.json`:
+   - `server.apiKey`
+   - `printDefaults.printerName` (opcional, vacío = impresora por defecto de Windows)
+   - tamaño y estilo (`ticketWidthMm`, márgenes, fuente, copias)
+4. Iniciar:
+   - `npm start`
+
+## API local
+
+### GET /health
+Respuesta de estado.
+
+### POST /print
+Headers:
+- `Content-Type: application/json`
+- `x-lai-api-key: <apiKey local>`
+
+Body:
+
+```json
+{
+  "ticketText": "JINETEADA LAI\n...",
+  "printConfig": {
+    "ticketWidthMm": 58,
+    "copies": 1,
+    "fontName": "Consolas",
+    "fontSize": 9,
+    "marginLeftMm": 2,
+    "marginRightMm": 2,
+    "marginTopMm": 2,
+    "marginBottomMm": 6,
+    "printerName": ""
+  }
+}
+```
+
+## Logs
+
+- Archivo: `logs/agent.log`
+- Guarda inicio, impresiones OK y errores.
+
+## Nota de seguridad
+
+- Escucha solamente en `127.0.0.1`.
+- Rechaza impresiones sin API key válida.

--- a/lai/local-print-agent-node/agent.js
+++ b/lai/local-print-agent-node/agent.js
@@ -1,0 +1,238 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+const { spawn } = require('child_process');
+
+const BASE_DIR = __dirname;
+const CONFIG_PATH = path.join(BASE_DIR, 'config.json');
+const CONFIG_EXAMPLE_PATH = path.join(BASE_DIR, 'config.example.json');
+const LOG_DIR = path.join(BASE_DIR, 'logs');
+const LOG_FILE = path.join(LOG_DIR, 'agent.log');
+const PRINT_SCRIPT_PATH = path.join(BASE_DIR, 'scripts', 'print_ticket.ps1');
+
+function ensureLogDir() {
+  if (!fs.existsSync(LOG_DIR)) {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+  }
+}
+
+function writeLog(level, message, extra = null) {
+  ensureLogDir();
+  const entry = {
+    ts: new Date().toISOString(),
+    level,
+    message,
+    extra,
+  };
+  fs.appendFileSync(LOG_FILE, `${JSON.stringify(entry)}${os.EOL}`);
+}
+
+function loadConfig() {
+  if (!fs.existsSync(CONFIG_PATH)) {
+    if (fs.existsSync(CONFIG_EXAMPLE_PATH)) {
+      fs.copyFileSync(CONFIG_EXAMPLE_PATH, CONFIG_PATH);
+      writeLog('WARN', 'No existía config.json. Se copió config.example.json automáticamente.');
+    } else {
+      throw new Error('No existe config.json ni config.example.json');
+    }
+  }
+
+  const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+      if (body.length > 1024 * 1024) {
+        reject(new Error('Payload demasiado grande (máximo 1MB)'));
+      }
+    });
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+function jsonResponse(res, statusCode, payload) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(payload));
+}
+
+function clampNumber(value, fallback, min, max) {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+}
+
+function normalizePrintConfig(agentConfig, jobConfig = {}) {
+  const defaults = agentConfig.printDefaults || {};
+  const ticketWidthMm = clampNumber(jobConfig.ticketWidthMm, defaults.ticketWidthMm || 58, 40, 120);
+  const charsPerLine = ticketWidthMm <= 58
+    ? clampNumber(jobConfig.charsPerLine, defaults.charsPerLine58 || 32, 20, 48)
+    : clampNumber(jobConfig.charsPerLine, defaults.charsPerLine80 || 42, 32, 72);
+
+  return {
+    printerName: String(jobConfig.printerName || defaults.printerName || ''),
+    copies: clampNumber(jobConfig.copies, defaults.copies || 1, 1, 5),
+    fontName: String(jobConfig.fontName || defaults.fontName || 'Consolas'),
+    fontSize: clampNumber(jobConfig.fontSize, defaults.fontSize || 9, 6, 14),
+    marginLeftMm: clampNumber(jobConfig.marginLeftMm, defaults.marginLeftMm || 2, 0, 10),
+    marginRightMm: clampNumber(jobConfig.marginRightMm, defaults.marginRightMm || 2, 0, 10),
+    marginTopMm: clampNumber(jobConfig.marginTopMm, defaults.marginTopMm || 2, 0, 20),
+    marginBottomMm: clampNumber(jobConfig.marginBottomMm, defaults.marginBottomMm || 6, 0, 30),
+    ticketWidthMm,
+    charsPerLine,
+  };
+}
+
+function wrapLine(line, maxChars) {
+  if (line.length <= maxChars) return [line];
+  const pieces = [];
+  let current = line;
+
+  while (current.length > maxChars) {
+    let splitAt = current.lastIndexOf(' ', maxChars);
+    if (splitAt <= 0) splitAt = maxChars;
+    pieces.push(current.slice(0, splitAt).trimEnd());
+    current = current.slice(splitAt).trimStart();
+  }
+
+  if (current.length > 0) {
+    pieces.push(current);
+  }
+
+  return pieces;
+}
+
+function normalizeText(rawText, charsPerLine) {
+  const safeText = String(rawText || '').replace(/\r\n/g, '\n');
+  const lines = safeText.split('\n');
+  const wrapped = [];
+
+  for (const line of lines) {
+    if (line === '') {
+      wrapped.push('');
+      continue;
+    }
+
+    wrapped.push(...wrapLine(line, charsPerLine));
+  }
+
+  return wrapped.join('\n');
+}
+
+function runPrintJob(payload) {
+  return new Promise((resolve, reject) => {
+    const tempFile = path.join(os.tmpdir(), `lai-print-job-${crypto.randomUUID()}.json`);
+    fs.writeFileSync(tempFile, JSON.stringify(payload), 'utf8');
+
+    const child = spawn('powershell.exe', [
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      PRINT_SCRIPT_PATH,
+      '-PayloadPath',
+      tempFile,
+    ]);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+
+    child.on('close', (code) => {
+      try {
+        fs.unlinkSync(tempFile);
+      } catch (err) {
+        writeLog('WARN', 'No se pudo borrar archivo temporal', { file: tempFile, err: err.message });
+      }
+
+      if (code === 0) {
+        resolve({ stdout: stdout.trim() });
+      } else {
+        reject(new Error(stderr.trim() || stdout.trim() || `Error de impresión (exit ${code})`));
+      }
+    });
+
+    child.on('error', (err) => reject(err));
+  });
+}
+
+function startServer() {
+  const config = loadConfig();
+  const host = config.server?.host || '127.0.0.1';
+  const port = Number(config.server?.port || 5399);
+  const apiKey = String(config.server?.apiKey || '');
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      return jsonResponse(res, 200, { status: 'ok', host, port });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/print') {
+      if (apiKey) {
+        const sentKey = String(req.headers['x-lai-api-key'] || '');
+        if (sentKey !== apiKey) {
+          writeLog('WARN', 'Intento de impresión con API key inválida');
+          return jsonResponse(res, 401, { ok: false, error: 'API key inválida' });
+        }
+      }
+
+      try {
+        const rawBody = await readBody(req);
+        const body = JSON.parse(rawBody);
+
+        if (!body || typeof body !== 'object') {
+          return jsonResponse(res, 400, { ok: false, error: 'Body inválido' });
+        }
+
+        const rawText = String(body.ticketText || '');
+        if (!rawText.trim()) {
+          return jsonResponse(res, 400, { ok: false, error: 'ticketText es obligatorio' });
+        }
+
+        const finalConfig = normalizePrintConfig(config, body.printConfig || {});
+        const normalizedText = normalizeText(rawText, finalConfig.charsPerLine);
+
+        const printPayload = {
+          ticketText: normalizedText,
+          printConfig: finalConfig,
+        };
+
+        await runPrintJob(printPayload);
+        writeLog('INFO', 'Ticket impreso', {
+          printerName: finalConfig.printerName || 'default',
+          ticketWidthMm: finalConfig.ticketWidthMm,
+          copies: finalConfig.copies,
+        });
+
+        return jsonResponse(res, 200, {
+          ok: true,
+          message: 'Impresión enviada',
+          appliedConfig: finalConfig,
+        });
+      } catch (err) {
+        writeLog('ERROR', 'Fallo de impresión', { error: err.message });
+        return jsonResponse(res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    return jsonResponse(res, 404, { ok: false, error: 'Ruta no encontrada' });
+  });
+
+  server.listen(port, host, () => {
+    writeLog('INFO', 'Agente iniciado', { host, port });
+    // eslint-disable-next-line no-console
+    console.log(`LAI Local Print Agent escuchando en http://${host}:${port}`);
+  });
+}
+
+startServer();

--- a/lai/local-print-agent-node/config.example.json
+++ b/lai/local-print-agent-node/config.example.json
@@ -1,0 +1,20 @@
+{
+  "server": {
+    "host": "127.0.0.1",
+    "port": 5399,
+    "apiKey": "CAMBIAR_ESTA_CLAVE_LOCAL"
+  },
+  "printDefaults": {
+    "printerName": "",
+    "copies": 1,
+    "fontName": "Consolas",
+    "fontSize": 9,
+    "marginLeftMm": 2,
+    "marginRightMm": 2,
+    "marginTopMm": 2,
+    "marginBottomMm": 6,
+    "ticketWidthMm": 58,
+    "charsPerLine58": 32,
+    "charsPerLine80": 42
+  }
+}

--- a/lai/local-print-agent-node/package.json
+++ b/lai/local-print-agent-node/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lai-local-print-agent",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Agente local de impresión para LAI (Windows)",
+  "main": "agent.js",
+  "scripts": {
+    "start": "node agent.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/lai/local-print-agent-node/scripts/print_ticket.ps1
+++ b/lai/local-print-agent-node/scripts/print_ticket.ps1
@@ -1,0 +1,97 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PayloadPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -Path $PayloadPath)) {
+  throw "No existe el payload: $PayloadPath"
+}
+
+$payload = Get-Content -Path $PayloadPath -Raw | ConvertFrom-Json
+$text = [string]$payload.ticketText
+$config = $payload.printConfig
+
+if ([string]::IsNullOrWhiteSpace($text)) {
+  throw "ticketText vacío"
+}
+
+Add-Type -AssemblyName System.Drawing
+
+function Convert-MmToHundredthsInch([double]$mm) {
+  return [int][Math]::Round($mm * 3.937)
+}
+
+$ticketWidthMm = [double]$config.ticketWidthMm
+if ($ticketWidthMm -le 0) { $ticketWidthMm = 58 }
+
+$marginLeft = Convert-MmToHundredthsInch([double]$config.marginLeftMm)
+$marginRight = Convert-MmToHundredthsInch([double]$config.marginRightMm)
+$marginTop = Convert-MmToHundredthsInch([double]$config.marginTopMm)
+$marginBottom = Convert-MmToHundredthsInch([double]$config.marginBottomMm)
+
+$fontName = [string]$config.fontName
+if ([string]::IsNullOrWhiteSpace($fontName)) { $fontName = 'Consolas' }
+$fontSize = [float]$config.fontSize
+if ($fontSize -le 0) { $fontSize = 9 }
+
+$copies = [int]$config.copies
+if ($copies -lt 1) { $copies = 1 }
+
+$printerName = [string]$config.printerName
+
+$lines = $text -split "`n"
+$lineIndex = 0
+
+$font = New-Object System.Drawing.Font($fontName, $fontSize)
+$brush = [System.Drawing.Brushes]::Black
+
+$printDoc = New-Object System.Drawing.Printing.PrintDocument
+$printDoc.DefaultPageSettings.Margins = New-Object System.Drawing.Printing.Margins($marginLeft, $marginRight, $marginTop, $marginBottom)
+$paperWidth = Convert-MmToHundredthsInch($ticketWidthMm)
+$paperHeight = 1200
+$printDoc.DefaultPageSettings.PaperSize = New-Object System.Drawing.Printing.PaperSize('Ticket', $paperWidth, $paperHeight)
+
+if (-not [string]::IsNullOrWhiteSpace($printerName)) {
+  $printDoc.PrinterSettings.PrinterName = $printerName
+}
+
+if (-not $printDoc.PrinterSettings.IsValid) {
+  throw "Impresora inválida o no disponible: '$printerName'"
+}
+
+$handler = [System.Drawing.Printing.PrintPageEventHandler]{
+  param($sender, $e)
+
+  $x = $e.MarginBounds.Left
+  $y = $e.MarginBounds.Top
+  $lineHeight = $font.GetHeight($e.Graphics)
+
+  while ($lineIndex -lt $lines.Length) {
+    if (($y + $lineHeight) -gt $e.MarginBounds.Bottom) {
+      $e.HasMorePages = $true
+      return
+    }
+
+    $line = $lines[$lineIndex]
+    $e.Graphics.DrawString($line, $font, $brush, $x, $y)
+    $y += $lineHeight
+    $lineIndex++
+  }
+
+  $e.HasMorePages = $false
+}
+
+$printDoc.add_PrintPage($handler)
+
+for ($i = 1; $i -le $copies; $i++) {
+  $lineIndex = 0
+  $printDoc.Print()
+}
+
+$printDoc.remove_PrintPage($handler)
+$printDoc.Dispose()
+$font.Dispose()
+
+Write-Output 'PRINT_OK'

--- a/lai/print_agent_config.php
+++ b/lai/print_agent_config.php
@@ -1,0 +1,17 @@
+<?php
+
+$PRINT_AGENT_ENABLED = true;
+$PRINT_AGENT_URL = 'http://127.0.0.1:5399/print';
+$PRINT_AGENT_API_KEY = 'CAMBIAR_ESTA_CLAVE_LOCAL';
+
+$PRINT_AGENT_DEFAULTS = array(
+    'ticketWidthMm' => 58,
+    'copies' => 1,
+    'fontName' => 'Consolas',
+    'fontSize' => 9,
+    'marginLeftMm' => 2,
+    'marginRightMm' => 2,
+    'marginTopMm' => 2,
+    'marginBottomMm' => 6,
+    'printerName' => ''
+);

--- a/lai/ventas_registradas.php
+++ b/lai/ventas_registradas.php
@@ -138,7 +138,7 @@ echo "</td>";
                             <input type='hidden' name='venta_id' value='{$id}'>
                             <button type='submit' name='anular' class='action-button cancel-button' onclick=\"return confirm('¿Estás seguro que deseas anular esta venta?');\">Anular</button>
                         </form>
-                        <button class='action-button' onclick=\"window.open('factura_tkt.php?producto={$producto}&precio={$precio}', '_blank');\">Imprimir</button>
+                        <button class='action-button' onclick=\"window.laiPrintTickets([{producto: " . json_encode($producto) . ", precio: " . json_encode($precio) . "}]);\">Imprimir</button>
                     </td>
                   </tr>";
         }


### PR DESCRIPTION
### Motivation
- El objetivo es desacoplar la impresión del navegador y eliminar la dependencia de `window.print`/popups manteniendo la aplicación PHP+MySQL y sin tocar la lógica de ventas ni la base de datos.
- Entregar un agente local en Windows que reciba el ticket desde la web y lo imprima directamente con control de tamaño (58/80 mm), márgenes y copias.

### Description
- Se añadió un agente Node.js en `lai/local-print-agent-node/` con `agent.js`, `package.json`, `config.example.json`, `README.md` y `scripts/print_ticket.ps1`; el agente escucha en `127.0.0.1` y expone `GET /health` y `POST /print` con validación por header `x-lai-api-key` y logs en `logs/agent.log`.
- La impresión en Windows se realiza por PowerShell (`scripts/print_ticket.ps1`) usando `System.Drawing.Printing.PrintDocument`, con parámetros configurables: `ticketWidthMm`, márgenes, `fontName`, `fontSize`, `copies` y `printerName`.
- Integración mínima en la web: nuevo `lai/print_agent_config.php` para habilitar/parametrizar el agente y cambios en `lai/index.php` que reemplazan el disparo directo de popups por envío al agente local en texto plano (`ticketText`), añaden una cola de trabajos pendientes y mantienen un fallback que abre `factura_tkt.php` si el agente falla o está deshabilitado.
- Se actualizó `lai/ventas_registradas.php` para que el botón `Imprimir` use el helper `window.laiPrintTickets(...)` en lugar de abrir directamente `factura_tkt.php`.
- Formato de ticket elegido: texto plano en el campo `ticketText` dentro del `POST /print` JSON para un control predecible del wrapping y ancho en impresoras térmicas.

### Testing
- Se verificó sintaxis PHP con `php -l` sobre `lai/index.php`, `lai/ventas_registradas.php` y `lai/print_agent_config.php` (todos sin errores).
- Se comprobó la sintaxis del agente Node.js con `node --check lai/local-print-agent-node/agent.js` (sin errores).
- No se ejecutaron pruebas de impresión física en este entorno; la integración conserva fallback a `factura_tkt.php` para no interrumpir la operación en caso de que el agente no esté disponible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e043a95cb08327a70555910043ed19)