### PR TITLE
Add local Windows print agent and integrate client-side printing with fallback

### DIFF
--- a/lai/index.php
+++ b/lai/index.php
@@ -1,5 +1,6 @@
 <?php
 include 'conexion.php';
+include 'print_agent_config.php';
 
 
 session_start();
@@ -82,22 +83,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['producto'])) {
     // Imprimir tickets
     echo '<script>
         const tickets = ' . json_encode($tickets) . ';
-        function imprimirTickets(tickets, index = 0) {
-            if (index >= tickets.length) return;
-            const ticket = tickets[index];
-            const ventana = window.open(
-                "factura_tkt.php?producto=" + encodeURIComponent(ticket.producto) + "&precio=" + ticket.precio,
-                "_blank",
-                "width=200,height=100,top=1000,left=2000"
-            );
-            const checkClosed = setInterval(() => {
-                if (ventana.closed) {
-                    clearInterval(checkClosed);
-                    setTimeout(() => imprimirTickets(tickets, index + 1), 500);
-                }
-            }, 300);
+        window.__laiPendingPrintJobs = window.__laiPendingPrintJobs || [];
+        window.__laiPendingPrintJobs.push(tickets);
+        if (window.laiPrintTickets) {
+            window.laiPrintTickets(tickets);
         }
-        imprimirTickets(tickets);
     </script>';
 }
 
@@ -208,26 +198,11 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['registrar_venta'])) {
         // Imprimir tickets uno por uno
         echo '<script>
             var tickets = ' . json_encode($tickets) . ';
-            function imprimirTickets(tickets, index) {
-                if (index === undefined) index = 0;
-                if (index >= tickets.length) return;
-                var ticket = tickets[index];
-                var ventana = window.open(
-                    "factura_tkt.php?producto=" + encodeURIComponent(ticket.producto) + "&precio=" + ticket.precio,
-                    "_blank",
-                    "width=200,height=100,top=1000,left=2000"
-                );
-
-                var checkClosed = setInterval(function() {
-                    if (ventana.closed) {
-                        clearInterval(checkClosed);
-                        setTimeout(function() {
-                            imprimirTickets(tickets, index + 1);
-                        }, 500);
-                    }
-                }, 300);
+            window.__laiPendingPrintJobs = window.__laiPendingPrintJobs || [];
+            window.__laiPendingPrintJobs.push(tickets);
+            if (window.laiPrintTickets) {
+                window.laiPrintTickets(tickets);
             }
-            imprimirTickets(tickets);
         </script>';
 
     } else {
@@ -357,9 +332,103 @@ if ($result_usuario && $result_usuario->num_rows > 0) {
 
 		
         </div>
-		
-		
+
+
     </div>
+<script>
+  (function () {
+    const AGENT_ENABLED = <?php echo $PRINT_AGENT_ENABLED ? 'true' : 'false'; ?>;
+    const AGENT_URL = <?php echo json_encode($PRINT_AGENT_URL); ?>;
+    const AGENT_API_KEY = <?php echo json_encode($PRINT_AGENT_API_KEY); ?>;
+    const AGENT_DEFAULTS = <?php echo json_encode($PRINT_AGENT_DEFAULTS); ?>;
+    const USUARIO = <?php echo json_encode($usuario_nombre); ?>;
+    const HORA = <?php echo json_encode(date('d/m/Y H:i:s', strtotime('+21 hours'))); ?>;
+
+    function formatPrecio(precio) {
+      const numero = Number(precio || 0);
+      if (Number.isNaN(numero)) {
+        return '0';
+      }
+      return Math.round(numero).toLocaleString('es-AR');
+    }
+
+    function construirTicketTexto(ticket) {
+      const producto = String(ticket.producto || 'Producto');
+      const precio = formatPrecio(ticket.precio);
+      const lineas = [
+        '- JINETEADA LAI -',
+        'PARA RETIRAR',
+        '------------------------------',
+        HORA,
+        'Atendido por: ' + USUARIO,
+        '------------------------------',
+        'Producto:',
+        producto,
+        '------------------------------',
+        'Precio: $ ' + precio,
+        '------------------------------',
+        'Gracias por su compra'
+      ];
+      return lineas.join('\n');
+    }
+
+    async function enviarAlAgente(ticket) {
+      const payload = {
+        ticketText: construirTicketTexto(ticket),
+        printConfig: AGENT_DEFAULTS
+      };
+
+      const response = await fetch(AGENT_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-lai-api-key': AGENT_API_KEY
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        const detalle = await response.text();
+        throw new Error('Agente respondió ' + response.status + ' - ' + detalle);
+      }
+    }
+
+    function printFallback(ticket) {
+      window.open(
+        'factura_tkt.php?producto=' + encodeURIComponent(ticket.producto) + '&precio=' + ticket.precio,
+        '_blank',
+        'width=200,height=100,top=1000,left=2000'
+      );
+    }
+
+    window.laiPrintTicketsFallback = function (tickets) {
+      (tickets || []).forEach(printFallback);
+    };
+
+    window.laiPrintTickets = async function (tickets) {
+      const lista = tickets || [];
+      for (const ticket of lista) {
+        try {
+          if (AGENT_ENABLED) {
+            await enviarAlAgente(ticket);
+            continue;
+          }
+        } catch (error) {
+          console.warn('Error en agente local, se usa fallback', error);
+        }
+        printFallback(ticket);
+      }
+    };
+
+    const pendientes = window.__laiPendingPrintJobs || [];
+    if (pendientes.length > 0) {
+      window.__laiPendingPrintJobs = [];
+      pendientes.forEach(function (tickets) {
+        window.laiPrintTickets(tickets);
+      });
+    }
+  })();
+</script>
 </body>
 </html>
 

--- a/lai/local-print-agent-node/README.md
+++ b/lai/local-print-agent-node/README.md
@@ -1,0 +1,105 @@
+# LAI Local Print Agent (Windows)
+
+Agente local para desacoplar la impresión del navegador en `/lai/`.
+
+## Requisitos
+
+- Windows 10/11
+- Node.js 18+
+- PowerShell 5+
+- Impresora térmica instalada en Windows
+
+## Instalación rápida (manual)
+
+1. Copiar esta carpeta a la PC (por ejemplo `C:\lai-print-agent`).
+2. Crear `config.json` desde el ejemplo:
+   - `copy config.example.json config.json`
+3. Editar `config.json`:
+   - `server.apiKey`
+   - `printDefaults.printerName` (opcional, vacío = impresora por defecto de Windows)
+   - tamaño y estilo (`ticketWidthMm`, márgenes, fuente, copias)
+4. Iniciar:
+   - `npm start`
+
+## Instalación automática en Windows (tipo instalador)
+
+Dentro de `windows/` tenés opciones para que la instalación sea ejecutable:
+
+- `install-agent.cmd`: doble click (ideal con click derecho `Ejecutar como administrador`).
+- `install-agent.ps1`: instalador por PowerShell con parámetros.
+- `build-installer-exe.ps1`: genera un `.exe` instalador usando `ps2exe`.
+
+### Opción A: instalar con CMD (sin compilar EXE)
+
+1. Editar variables en `windows/install-agent.cmd`:
+   - `API_KEY`
+   - `PRINTER_NAME`
+   - `TICKET_WIDTH` (58/80)
+   - `AGENT_PORT`
+2. Ejecutar como administrador.
+
+Esto:
+- instala Node.js LTS con `winget` si falta,
+- copia archivos a `C:\LAI\PrintAgent`,
+- genera `config.json`,
+- crea servicio Windows `LAIPrintAgent`,
+- inicia y valida `GET /health`.
+
+### Opción B: generar un EXE instalador
+
+En PowerShell (Windows):
+
+```powershell
+cd .\windows
+.\build-installer-exe.ps1
+```
+
+Luego ejecutar `LAI-Print-Agent-Installer.exe` como administrador.
+
+> Importante: distribuir el EXE junto a la carpeta del agente (debe tener `agent.js`, `scripts\`, etc.).
+
+## API local
+
+### GET /health
+Respuesta de estado.
+
+### POST /print
+Headers:
+- `Content-Type: application/json`
+- `x-lai-api-key: <apiKey local>`
+
+Body:
+
+```json
+{
+  "ticketText": "JINETEADA LAI\n...",
+  "printConfig": {
+    "ticketWidthMm": 58,
+    "copies": 1,
+    "fontName": "Consolas",
+    "fontSize": 9,
+    "marginLeftMm": 2,
+    "marginRightMm": 2,
+    "marginTopMm": 2,
+    "marginBottomMm": 6,
+    "printerName": ""
+  }
+}
+```
+
+## Logs
+
+- Archivo: `logs/agent.log`
+- Guarda inicio, impresiones OK y errores.
+
+## Nota de seguridad
+
+- Escucha solamente en `127.0.0.1`.
+- Rechaza impresiones sin API key válida.
+
+## Desinstalación
+
+```powershell
+cd .\windows
+.\uninstall-agent.ps1
+```

--- a/lai/local-print-agent-node/agent.js
+++ b/lai/local-print-agent-node/agent.js
@@ -1,0 +1,238 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+const { spawn } = require('child_process');
+
+const BASE_DIR = __dirname;
+const CONFIG_PATH = path.join(BASE_DIR, 'config.json');
+const CONFIG_EXAMPLE_PATH = path.join(BASE_DIR, 'config.example.json');
+const LOG_DIR = path.join(BASE_DIR, 'logs');
+const LOG_FILE = path.join(LOG_DIR, 'agent.log');
+const PRINT_SCRIPT_PATH = path.join(BASE_DIR, 'scripts', 'print_ticket.ps1');
+
+function ensureLogDir() {
+  if (!fs.existsSync(LOG_DIR)) {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+  }
+}
+
+function writeLog(level, message, extra = null) {
+  ensureLogDir();
+  const entry = {
+    ts: new Date().toISOString(),
+    level,
+    message,
+    extra,
+  };
+  fs.appendFileSync(LOG_FILE, `${JSON.stringify(entry)}${os.EOL}`);
+}
+
+function loadConfig() {
+  if (!fs.existsSync(CONFIG_PATH)) {
+    if (fs.existsSync(CONFIG_EXAMPLE_PATH)) {
+      fs.copyFileSync(CONFIG_EXAMPLE_PATH, CONFIG_PATH);
+      writeLog('WARN', 'No existía config.json. Se copió config.example.json automáticamente.');
+    } else {
+      throw new Error('No existe config.json ni config.example.json');
+    }
+  }
+
+  const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+      if (body.length > 1024 * 1024) {
+        reject(new Error('Payload demasiado grande (máximo 1MB)'));
+      }
+    });
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+function jsonResponse(res, statusCode, payload) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(payload));
+}
+
+function clampNumber(value, fallback, min, max) {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+}
+
+function normalizePrintConfig(agentConfig, jobConfig = {}) {
+  const defaults = agentConfig.printDefaults || {};
+  const ticketWidthMm = clampNumber(jobConfig.ticketWidthMm, defaults.ticketWidthMm || 58, 40, 120);
+  const charsPerLine = ticketWidthMm <= 58
+    ? clampNumber(jobConfig.charsPerLine, defaults.charsPerLine58 || 32, 20, 48)
+    : clampNumber(jobConfig.charsPerLine, defaults.charsPerLine80 || 42, 32, 72);
+
+  return {
+    printerName: String(jobConfig.printerName || defaults.printerName || ''),
+    copies: clampNumber(jobConfig.copies, defaults.copies || 1, 1, 5),
+    fontName: String(jobConfig.fontName || defaults.fontName || 'Consolas'),
+    fontSize: clampNumber(jobConfig.fontSize, defaults.fontSize || 9, 6, 14),
+    marginLeftMm: clampNumber(jobConfig.marginLeftMm, defaults.marginLeftMm || 2, 0, 10),
+    marginRightMm: clampNumber(jobConfig.marginRightMm, defaults.marginRightMm || 2, 0, 10),
+    marginTopMm: clampNumber(jobConfig.marginTopMm, defaults.marginTopMm || 2, 0, 20),
+    marginBottomMm: clampNumber(jobConfig.marginBottomMm, defaults.marginBottomMm || 6, 0, 30),
+    ticketWidthMm,
+    charsPerLine,
+  };
+}
+
+function wrapLine(line, maxChars) {
+  if (line.length <= maxChars) return [line];
+  const pieces = [];
+  let current = line;
+
+  while (current.length > maxChars) {
+    let splitAt = current.lastIndexOf(' ', maxChars);
+    if (splitAt <= 0) splitAt = maxChars;
+    pieces.push(current.slice(0, splitAt).trimEnd());
+    current = current.slice(splitAt).trimStart();
+  }
+
+  if (current.length > 0) {
+    pieces.push(current);
+  }
+
+  return pieces;
+}
+
+function normalizeText(rawText, charsPerLine) {
+  const safeText = String(rawText || '').replace(/\r\n/g, '\n');
+  const lines = safeText.split('\n');
+  const wrapped = [];
+
+  for (const line of lines) {
+    if (line === '') {
+      wrapped.push('');
+      continue;
+    }
+
+    wrapped.push(...wrapLine(line, charsPerLine));
+  }
+
+  return wrapped.join('\n');
+}
+
+function runPrintJob(payload) {
+  return new Promise((resolve, reject) => {
+    const tempFile = path.join(os.tmpdir(), `lai-print-job-${crypto.randomUUID()}.json`);
+    fs.writeFileSync(tempFile, JSON.stringify(payload), 'utf8');
+
+    const child = spawn('powershell.exe', [
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      PRINT_SCRIPT_PATH,
+      '-PayloadPath',
+      tempFile,
+    ]);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+
+    child.on('close', (code) => {
+      try {
+        fs.unlinkSync(tempFile);
+      } catch (err) {
+        writeLog('WARN', 'No se pudo borrar archivo temporal', { file: tempFile, err: err.message });
+      }
+
+      if (code === 0) {
+        resolve({ stdout: stdout.trim() });
+      } else {
+        reject(new Error(stderr.trim() || stdout.trim() || `Error de impresión (exit ${code})`));
+      }
+    });
+
+    child.on('error', (err) => reject(err));
+  });
+}
+
+function startServer() {
+  const config = loadConfig();
+  const host = config.server?.host || '127.0.0.1';
+  const port = Number(config.server?.port || 5399);
+  const apiKey = String(config.server?.apiKey || '');
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      return jsonResponse(res, 200, { status: 'ok', host, port });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/print') {
+      if (apiKey) {
+        const sentKey = String(req.headers['x-lai-api-key'] || '');
+        if (sentKey !== apiKey) {
+          writeLog('WARN', 'Intento de impresión con API key inválida');
+          return jsonResponse(res, 401, { ok: false, error: 'API key inválida' });
+        }
+      }
+
+      try {
+        const rawBody = await readBody(req);
+        const body = JSON.parse(rawBody);
+
+        if (!body || typeof body !== 'object') {
+          return jsonResponse(res, 400, { ok: false, error: 'Body inválido' });
+        }
+
+        const rawText = String(body.ticketText || '');
+        if (!rawText.trim()) {
+          return jsonResponse(res, 400, { ok: false, error: 'ticketText es obligatorio' });
+        }
+
+        const finalConfig = normalizePrintConfig(config, body.printConfig || {});
+        const normalizedText = normalizeText(rawText, finalConfig.charsPerLine);
+
+        const printPayload = {
+          ticketText: normalizedText,
+          printConfig: finalConfig,
+        };
+
+        await runPrintJob(printPayload);
+        writeLog('INFO', 'Ticket impreso', {
+          printerName: finalConfig.printerName || 'default',
+          ticketWidthMm: finalConfig.ticketWidthMm,
+          copies: finalConfig.copies,
+        });
+
+        return jsonResponse(res, 200, {
+          ok: true,
+          message: 'Impresión enviada',
+          appliedConfig: finalConfig,
+        });
+      } catch (err) {
+        writeLog('ERROR', 'Fallo de impresión', { error: err.message });
+        return jsonResponse(res, 500, { ok: false, error: err.message });
+      }
+    }
+
+    return jsonResponse(res, 404, { ok: false, error: 'Ruta no encontrada' });
+  });
+
+  server.listen(port, host, () => {
+    writeLog('INFO', 'Agente iniciado', { host, port });
+    // eslint-disable-next-line no-console
+    console.log(`LAI Local Print Agent escuchando en http://${host}:${port}`);
+  });
+}
+
+startServer();

--- a/lai/local-print-agent-node/config.example.json
+++ b/lai/local-print-agent-node/config.example.json
@@ -1,0 +1,20 @@
+{
+  "server": {
+    "host": "127.0.0.1",
+    "port": 5399,
+    "apiKey": "CAMBIAR_ESTA_CLAVE_LOCAL"
+  },
+  "printDefaults": {
+    "printerName": "",
+    "copies": 1,
+    "fontName": "Consolas",
+    "fontSize": 9,
+    "marginLeftMm": 2,
+    "marginRightMm": 2,
+    "marginTopMm": 2,
+    "marginBottomMm": 6,
+    "ticketWidthMm": 58,
+    "charsPerLine58": 32,
+    "charsPerLine80": 42
+  }
+}

--- a/lai/local-print-agent-node/package.json
+++ b/lai/local-print-agent-node/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lai-local-print-agent",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Agente local de impresión para LAI (Windows)",
+  "main": "agent.js",
+  "scripts": {
+    "start": "node agent.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/lai/local-print-agent-node/scripts/print_ticket.ps1
+++ b/lai/local-print-agent-node/scripts/print_ticket.ps1
@@ -1,0 +1,97 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PayloadPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -Path $PayloadPath)) {
+  throw "No existe el payload: $PayloadPath"
+}
+
+$payload = Get-Content -Path $PayloadPath -Raw | ConvertFrom-Json
+$text = [string]$payload.ticketText
+$config = $payload.printConfig
+
+if ([string]::IsNullOrWhiteSpace($text)) {
+  throw "ticketText vacío"
+}
+
+Add-Type -AssemblyName System.Drawing
+
+function Convert-MmToHundredthsInch([double]$mm) {
+  return [int][Math]::Round($mm * 3.937)
+}
+
+$ticketWidthMm = [double]$config.ticketWidthMm
+if ($ticketWidthMm -le 0) { $ticketWidthMm = 58 }
+
+$marginLeft = Convert-MmToHundredthsInch([double]$config.marginLeftMm)
+$marginRight = Convert-MmToHundredthsInch([double]$config.marginRightMm)
+$marginTop = Convert-MmToHundredthsInch([double]$config.marginTopMm)
+$marginBottom = Convert-MmToHundredthsInch([double]$config.marginBottomMm)
+
+$fontName = [string]$config.fontName
+if ([string]::IsNullOrWhiteSpace($fontName)) { $fontName = 'Consolas' }
+$fontSize = [float]$config.fontSize
+if ($fontSize -le 0) { $fontSize = 9 }
+
+$copies = [int]$config.copies
+if ($copies -lt 1) { $copies = 1 }
+
+$printerName = [string]$config.printerName
+
+$lines = $text -split "`n"
+$lineIndex = 0
+
+$font = New-Object System.Drawing.Font($fontName, $fontSize)
+$brush = [System.Drawing.Brushes]::Black
+
+$printDoc = New-Object System.Drawing.Printing.PrintDocument
+$printDoc.DefaultPageSettings.Margins = New-Object System.Drawing.Printing.Margins($marginLeft, $marginRight, $marginTop, $marginBottom)
+$paperWidth = Convert-MmToHundredthsInch($ticketWidthMm)
+$paperHeight = 1200
+$printDoc.DefaultPageSettings.PaperSize = New-Object System.Drawing.Printing.PaperSize('Ticket', $paperWidth, $paperHeight)
+
+if (-not [string]::IsNullOrWhiteSpace($printerName)) {
+  $printDoc.PrinterSettings.PrinterName = $printerName
+}
+
+if (-not $printDoc.PrinterSettings.IsValid) {
+  throw "Impresora inválida o no disponible: '$printerName'"
+}
+
+$handler = [System.Drawing.Printing.PrintPageEventHandler]{
+  param($sender, $e)
+
+  $x = $e.MarginBounds.Left
+  $y = $e.MarginBounds.Top
+  $lineHeight = $font.GetHeight($e.Graphics)
+
+  while ($lineIndex -lt $lines.Length) {
+    if (($y + $lineHeight) -gt $e.MarginBounds.Bottom) {
+      $e.HasMorePages = $true
+      return
+    }
+
+    $line = $lines[$lineIndex]
+    $e.Graphics.DrawString($line, $font, $brush, $x, $y)
+    $y += $lineHeight
+    $lineIndex++
+  }
+
+  $e.HasMorePages = $false
+}
+
+$printDoc.add_PrintPage($handler)
+
+for ($i = 1; $i -le $copies; $i++) {
+  $lineIndex = 0
+  $printDoc.Print()
+}
+
+$printDoc.remove_PrintPage($handler)
+$printDoc.Dispose()
+$font.Dispose()
+
+Write-Output 'PRINT_OK'

--- a/lai/local-print-agent-node/windows/build-installer-exe.ps1
+++ b/lai/local-print-agent-node/windows/build-installer-exe.ps1
@@ -1,0 +1,23 @@
+param(
+  [string]$OutputExe = '.\LAI-Print-Agent-Installer.exe'
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host '[LAI BUILD] Verificando módulo ps2exe...' -ForegroundColor Cyan
+$module = Get-Module -ListAvailable -Name ps2exe
+if (-not $module) {
+  Install-Module -Name ps2exe -Scope CurrentUser -Force
+}
+
+Import-Module ps2exe
+
+$scriptPath = Join-Path $PSScriptRoot 'install-agent.ps1'
+if (-not (Test-Path $scriptPath)) {
+  throw "No existe install-agent.ps1 en: $scriptPath"
+}
+
+Invoke-PS2EXE -InputFile $scriptPath -OutputFile $OutputExe -NoConsole -RequireAdmin -Title 'LAI Print Agent Installer'
+
+Write-Host "[LAI BUILD] Instalador generado en: $OutputExe" -ForegroundColor Green
+Write-Host '[LAI BUILD] Importante: el EXE debe distribuirse junto a la carpeta del agente (agent.js, scripts, etc.).' -ForegroundColor Yellow

--- a/lai/local-print-agent-node/windows/install-agent.cmd
+++ b/lai/local-print-agent-node/windows/install-agent.cmd
@@ -1,0 +1,21 @@
+@echo off
+setlocal
+
+REM Ajusta estos valores antes de ejecutar si lo necesitás:
+set API_KEY=CAMBIAR_ESTA_CLAVE_LOCAL
+set PRINTER_NAME=
+set TICKET_WIDTH=58
+set AGENT_PORT=5399
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install-agent.ps1" -ApiKey "%API_KEY%" -PrinterName "%PRINTER_NAME%" -TicketWidthMm %TICKET_WIDTH% -Port %AGENT_PORT%
+
+if %ERRORLEVEL% neq 0 (
+  echo.
+  echo [ERROR] La instalacion fallo. Revisa el mensaje de PowerShell.
+  pause
+  exit /b %ERRORLEVEL%
+)
+
+echo.
+echo [OK] Instalacion completada.
+pause

--- a/lai/local-print-agent-node/windows/install-agent.ps1
+++ b/lai/local-print-agent-node/windows/install-agent.ps1
@@ -1,0 +1,168 @@
+param(
+  [string]$ApiKey = 'CAMBIAR_ESTA_CLAVE_LOCAL',
+  [string]$PrinterName = '',
+  [ValidateSet(58,80)]
+  [int]$TicketWidthMm = 58,
+  [int]$Port = 5399,
+  [string]$InstallDir = 'C:\LAI\PrintAgent',
+  [string]$ServiceName = 'LAIPrintAgent'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step([string]$msg) {
+  Write-Host "[LAI INSTALL] $msg" -ForegroundColor Cyan
+}
+
+function Assert-Admin {
+  $currentUser = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+  if (-not $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'Ejecutá este instalador como Administrador.'
+  }
+}
+
+function Ensure-Node {
+  $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+  if ($nodeCmd) {
+    $version = (& node -v).TrimStart('v')
+    $major = [int]($version.Split('.')[0])
+    if ($major -ge 18) {
+      Write-Step "Node.js detectado: v$version"
+      return
+    }
+  }
+
+  Write-Step 'Node.js >= 18 no detectado. Intentando instalar con winget...'
+  $wingetCmd = Get-Command winget -ErrorAction SilentlyContinue
+  if (-not $wingetCmd) {
+    throw 'No se encontró winget. Instalá Node.js LTS manualmente y reintentá.'
+  }
+
+  winget install --id OpenJS.NodeJS.LTS --source winget --accept-package-agreements --accept-source-agreements --silent
+
+  $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')
+  $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+  if (-not $nodeCmd) {
+    throw 'Node.js no quedó disponible en PATH luego de instalar. Reiniciá sesión e intentá nuevamente.'
+  }
+
+  $version = (& node -v).TrimStart('v')
+  $major = [int]($version.Split('.')[0])
+  if ($major -lt 18) {
+    throw "La versión de Node.js detectada ($version) es menor a 18."
+  }
+
+  Write-Step "Node.js instalado: v$version"
+}
+
+function Stop-And-RemoveService([string]$name) {
+  $svc = Get-Service -Name $name -ErrorAction SilentlyContinue
+  if ($svc) {
+    if ($svc.Status -ne 'Stopped') {
+      Write-Step "Deteniendo servicio existente: $name"
+      Stop-Service -Name $name -Force
+    }
+
+    Write-Step "Eliminando servicio existente: $name"
+    sc.exe delete $name | Out-Null
+    Start-Sleep -Seconds 1
+  }
+}
+
+Assert-Admin
+Ensure-Node
+
+$scriptDir = Split-Path -Parent $PSCommandPath
+$sourceRoot = Resolve-Path (Join-Path $scriptDir '..')
+
+Write-Step "Instalando en: $InstallDir"
+New-Item -Path $InstallDir -ItemType Directory -Force | Out-Null
+
+$sourceFiles = @('agent.js', 'package.json', 'config.example.json', 'scripts')
+foreach ($item in $sourceFiles) {
+  $sourcePath = Join-Path $sourceRoot $item
+  if (-not (Test-Path $sourcePath)) {
+    throw "No se encontró el archivo requerido: $sourcePath"
+  }
+
+  $destPath = Join-Path $InstallDir $item
+  if (Test-Path $destPath) {
+    Remove-Item -Path $destPath -Recurse -Force
+  }
+
+  Copy-Item -Path $sourcePath -Destination $destPath -Recurse -Force
+}
+
+$charsPerLine58 = 32
+$charsPerLine80 = 42
+if ($TicketWidthMm -eq 80) {
+  $charsPerLine58 = 32
+  $charsPerLine80 = 42
+}
+
+$config = @{
+  server = @{
+    host = '127.0.0.1'
+    port = $Port
+    apiKey = $ApiKey
+  }
+  printDefaults = @{
+    printerName = $PrinterName
+    copies = 1
+    fontName = 'Consolas'
+    fontSize = 9
+    marginLeftMm = 2
+    marginRightMm = 2
+    marginTopMm = 2
+    marginBottomMm = 6
+    ticketWidthMm = $TicketWidthMm
+    charsPerLine58 = $charsPerLine58
+    charsPerLine80 = $charsPerLine80
+  }
+}
+
+$configPath = Join-Path $InstallDir 'config.json'
+$config | ConvertTo-Json -Depth 5 | Out-File -FilePath $configPath -Encoding UTF8
+
+$logDir = Join-Path $InstallDir 'logs'
+New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+
+$nodePath = (Get-Command node).Source
+$agentPath = Join-Path $InstallDir 'agent.js'
+$binPath = "\"$nodePath\" \"$agentPath\""
+
+Stop-And-RemoveService -name $ServiceName
+
+Write-Step "Creando servicio Windows: $ServiceName"
+sc.exe create $ServiceName binPath= $binPath start= auto DisplayName= 'LAI Local Print Agent' | Out-Null
+sc.exe failure $ServiceName reset= 60 actions= restart/5000 | Out-Null
+
+Write-Step 'Iniciando servicio...'
+Start-Service -Name $ServiceName
+
+Start-Sleep -Seconds 2
+
+try {
+  $healthUrl = "http://127.0.0.1:$Port/health"
+  $health = Invoke-RestMethod -Uri $healthUrl -Method GET -TimeoutSec 3
+  if ($health.status -ne 'ok') {
+    throw 'El endpoint /health no devolvió ok.'
+  }
+} catch {
+  throw "Servicio instalado, pero /health falló. Revisá logs en $logDir. Error: $($_.Exception.Message)"
+}
+
+$summaryPath = Join-Path $InstallDir 'INSTALL_SUMMARY.txt'
+@(
+  "LAI Local Print Agent instalado correctamente.",
+  "",
+  "Servicio: $ServiceName",
+  "Carpeta: $InstallDir",
+  "URL local: http://127.0.0.1:$Port/print",
+  "API Key: $ApiKey",
+  "",
+  "Asegurate de actualizar lai/print_agent_config.php con esta misma API Key y puerto."
+) | Out-File -FilePath $summaryPath -Encoding UTF8
+
+Write-Step 'Instalación completada OK.'
+Write-Host "Resumen: $summaryPath" -ForegroundColor Green

--- a/lai/local-print-agent-node/windows/uninstall-agent.ps1
+++ b/lai/local-print-agent-node/windows/uninstall-agent.ps1
@@ -1,0 +1,23 @@
+param(
+  [string]$InstallDir = 'C:\LAI\PrintAgent',
+  [string]$ServiceName = 'LAIPrintAgent'
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "[LAI UNINSTALL] Deteniendo y eliminando servicio $ServiceName" -ForegroundColor Yellow
+
+$svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($svc) {
+  if ($svc.Status -ne 'Stopped') {
+    Stop-Service -Name $ServiceName -Force
+  }
+  sc.exe delete $ServiceName | Out-Null
+}
+
+if (Test-Path $InstallDir) {
+  Write-Host "[LAI UNINSTALL] Eliminando carpeta $InstallDir" -ForegroundColor Yellow
+  Remove-Item -Path $InstallDir -Recurse -Force
+}
+
+Write-Host '[LAI UNINSTALL] Desinstalación completada.' -ForegroundColor Green

--- a/lai/print_agent_config.php
+++ b/lai/print_agent_config.php
@@ -1,0 +1,18 @@
+<?php
+
+$PRINT_AGENT_ENABLED = true;
+$PRINT_AGENT_URL = 'http://127.0.0.1:5399/print';
+// Debe coincidir con la API key configurada por el instalador local (windows/install-agent.ps1)
+$PRINT_AGENT_API_KEY = 'CAMBIAR_ESTA_CLAVE_LOCAL';
+
+$PRINT_AGENT_DEFAULTS = array(
+    'ticketWidthMm' => 58,
+    'copies' => 1,
+    'fontName' => 'Consolas',
+    'fontSize' => 9,
+    'marginLeftMm' => 2,
+    'marginRightMm' => 2,
+    'marginTopMm' => 2,
+    'marginBottomMm' => 6,
+    'printerName' => ''
+);

--- a/lai/ventas_registradas.php
+++ b/lai/ventas_registradas.php
@@ -138,7 +138,7 @@ echo "</td>";
                             <input type='hidden' name='venta_id' value='{$id}'>
                             <button type='submit' name='anular' class='action-button cancel-button' onclick=\"return confirm('¿Estás seguro que deseas anular esta venta?');\">Anular</button>
                         </form>
-                        <button class='action-button' onclick=\"window.open('factura_tkt.php?producto={$producto}&precio={$precio}', '_blank');\">Imprimir</button>
+                        <button class='action-button' onclick=\"window.laiPrintTickets([{producto: " . json_encode($producto) . ", precio: " . json_encode($precio) . "}]);\">Imprimir</button>
                     </td>
                   </tr>";
         }


### PR DESCRIPTION
### Motivation

- Decouple thermal ticket printing from the browser to improve reliability and allow printing via a local Windows service. 
- Provide a local API so the web app can send print jobs programmatically and fall back to the previous popup method when the agent is unavailable.

### Description

- Wire the app to a new print configuration by adding `lai/print_agent_config.php` and including it from `lai/index.php` to control agent usage and defaults. 
- Replace the previous `window.open`-based print flow with a queued client-side API (`window.laiPrintTickets`) in `lai/index.php` that posts normalized ticket text to a local HTTP print agent and falls back to `factura_tkt.php` popups on failure. 
- Add a lightweight local print agent implementation under `lai/local-print-agent-node/` including `agent.js`, `package.json`, `config.example.json`, a PowerShell printing script `scripts/print_ticket.ps1`, installer/uninstaller and packaging helpers under `windows/`, and usage docs in `README.md`. 
- Update `lai/ventas_registradas.php` to call `window.laiPrintTickets` for on-demand printing of single recorded sales. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e043a95cb08327a70555910043ed19)