### PR TITLE
Windows LAI Print Agent: installer, scripts, default port/config updates and start/stop tooling

### DIFF
--- a/lai/local-print-agent-node/README.md
+++ b/lai/local-print-agent-node/README.md
@@ -32,6 +32,12 @@ Si `ISCC.exe` no está en ruta estándar, indicar path manual:
 powershell -NoProfile -ExecutionPolicy Bypass -File ".\scripts\build_installer.ps1" -InnoSetupCompiler "C:\Ruta\A\ISCC.exe"
 ```
 
+Si instalaste con `winget` y no sabés la ruta, buscá `ISCC.exe` así:
+
+```powershell
+Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages" -Filter ISCC.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 5 -ExpandProperty FullName
+```
+
 Salida esperada:
 
 - `lai\local-print-agent-node\installer\LAI-Print-Agent-Setup.exe`

--- a/lai/local-print-agent-node/README.md
+++ b/lai/local-print-agent-node/README.md
@@ -38,6 +38,12 @@ Si instalaste con `winget` y no sabés la ruta, buscá `ISCC.exe` así:
 Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages" -Filter ISCC.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 5 -ExpandProperty FullName
 ```
 
+También verificá instalación por usuario:
+
+```powershell
+Test-Path "$env:LOCALAPPDATA\Programs\Inno Setup 6\ISCC.exe"
+```
+
 Salida esperada:
 
 - `lai\local-print-agent-node\installer\LAI-Print-Agent-Setup.exe`

--- a/lai/local-print-agent-node/README.md
+++ b/lai/local-print-agent-node/README.md
@@ -26,6 +26,12 @@ En Windows con Inno Setup 6 instalado:
 powershell -NoProfile -ExecutionPolicy Bypass -File ".\scripts\build_installer.ps1"
 ```
 
+Si `ISCC.exe` no está en ruta estándar, indicar path manual:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\scripts\build_installer.ps1" -InnoSetupCompiler "C:\Ruta\A\ISCC.exe"
+```
+
 Salida esperada:
 
 - `lai\local-print-agent-node\installer\LAI-Print-Agent-Setup.exe`

--- a/lai/local-print-agent-node/README.md
+++ b/lai/local-print-agent-node/README.md
@@ -1,93 +1,119 @@
 # LAI Local Print Agent (Windows)
 
-Agente local para desacoplar la impresión del navegador en `/lai/`, pensado para desplegarse en múltiples PCs con un instalador `.exe`.
+Instalación y ejecución real del agente local de impresión en Windows con `.exe`.
 
-## Objetivo de despliegue
+## Qué instala `LAI-Print-Agent-Setup.exe`
 
-Cada PC solo debe:
+En `C:\Program Files\LAI Print Agent`:
 
-1. Ejecutar el instalador `LAI-Print-Agent-Setup.exe`.
-2. Elegir impresora y ancho de ticket durante el asistente.
-3. Finalizar, y dejar el agente listo (opcional: auto inicio con Windows).
+- `agent.js` (API local `GET /health` y `POST /print`)
+- `runtime\node.exe` (runtime embebido)
+- `scripts\install_agent.ps1` (configura + arranca)
+- `scripts\start_agent.ps1` (inicia proceso oculto)
+- `scripts\stop_agent.ps1` (detiene proceso)
+- `scripts\validate_agent.ps1` (prueba health + print)
+- `scripts\set_base_url.ps1` (actualiza dominio/URL del sistema sin reinstalar)
+- `config.json` (generado desde `config.example.json`)
+- `logs\agent.log`, `logs\agent-stdout.log`, `logs\agent-stderr.log`
 
-Sin instalación manual de dependencias una por una.
+## Cómo generar el `.exe` instalador
 
-## Arquitectura propuesta (Windows-first)
+El archivo `.exe` no se guarda en el repo (binario), se compila desde `installer/LAIPrintAgent.iss`.
 
-- **Runtime del agente:** Node.js embebido dentro del instalador (portable runtime copiado en `runtime/`).
-- **Ejecutable principal del agente:** `run-agent.cmd` (entrypoint estable para servicio/tarea).
-- **Instalador:** Inno Setup (`installer/LAIPrintAgent.iss`).
-- **Autoejecución:** Scheduled Task por usuario o por equipo (`scripts/install_agent.ps1`).
-- **Configuración local:** `config.json` con defaults por PC.
+En Windows con Inno Setup 6 instalado:
 
-## Componentes incluidos
-
-- `agent.js`: API local `GET /health` y `POST /print`.
-- `scripts/print_ticket.ps1`: impresión térmica usando APIs de impresión de Windows.
-- `scripts/install_agent.ps1`: registra tarea programada y configura `config.json`.
-- `scripts/uninstall_agent.ps1`: elimina tarea programada.
-- `installer/LAIPrintAgent.iss`: instalador `.exe` con asistentes y parámetros.
-
-## Configuración por PC
-
-El instalador permite definir:
-
-- URL base del sistema (por defecto `http://192.168.0.113/lai/`).
-- `apiKey` local del agente.
-- Impresora por nombre (`printerName`, vacío = default de Windows).
-- Ancho del ticket (`ticketWidthMm`, recomendado 58 u 80).
-- Auto inicio al loguear en Windows.
-
-## Flujo recomendado de build y empaquetado
-
-1. Preparar runtime Node portátil en `runtime/node.exe`.
-2. Generar artefacto de instalación con Inno Setup:
-   - Abrir `installer/LAIPrintAgent.iss` en Inno Setup.
-   - Compilar y obtener `LAI-Print-Agent-Setup.exe`.
-
-> Nota: si se prefiere, se puede reemplazar el runtime portable por un ejecutable único generado con `pkg`/`nexe`. El flujo de instalador no cambia.
-
-## API local
-
-### GET /health
-Respuesta de estado.
-
-### POST /print
-Headers:
-- `Content-Type: application/json`
-- `x-lai-api-key: <apiKey local>`
-
-Body:
-
-```json
-{
-  "ticketText": "JINETEADA LAI\n...",
-  "printConfig": {
-    "ticketWidthMm": 58,
-    "copies": 1,
-    "fontName": "Consolas",
-    "fontSize": 9,
-    "marginLeftMm": 2,
-    "marginRightMm": 2,
-    "marginTopMm": 2,
-    "marginBottomMm": 6,
-    "printerName": ""
-  }
-}
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\scripts\build_installer.ps1"
 ```
 
-## Integración con `/lai/`
+Salida esperada:
 
-- El frontend/backend en `http://192.168.0.113/lai/` debe enviar el ticket a `http://127.0.0.1:5399/print`.
-- Usar la API key configurada en cada PC.
-- Mantener fallback visual si el agente no responde.
+- `lai\local-print-agent-node\installer\LAI-Print-Agent-Setup.exe`
 
-## Logs
+## Flujo real en Windows (PC limpia)
 
-- Archivo: `logs/agent.log`
-- Guarda inicio, impresiones OK y errores.
+1. Ejecutar `LAI-Print-Agent-Setup.exe` como administrador.
+2. Completar asistente:
+   - URL base del sistema web (dominio online, opcional y editable).
+   - API Key local.
+   - Nombre de impresora (o vacío para predeterminada de Windows).
+   - Ancho ticket (solo 58 u 80).
+   - (Opcional) activar “Iniciar automáticamente al iniciar sesión”.
+3. Finalizar instalación.
+4. El instalador ejecuta `install_agent.ps1`, que:
+   - escribe `config.json`,
+   - crea Scheduled Task (si se marcó autostart),
+   - arranca el agente oculto inmediatamente.
 
-## Nota de seguridad
+## Validación obligatoria (en la PC Windows)
 
-- Escucha solamente en `127.0.0.1`.
-- Rechaza impresiones sin API key válida.
+### 1) Verificar que responde health
+
+Abrir navegador:
+
+- `http://127.0.0.1:3000/health`
+
+Respuesta esperada:
+
+```json
+{"status":"ok","host":"127.0.0.1","port":3000}
+```
+
+### 2) Verificar impresión real
+
+PowerShell:
+
+```powershell
+Invoke-RestMethod -Method Post -Uri "http://127.0.0.1:3000/print" `
+  -Headers @{ "x-lai-api-key" = "TU_API_KEY"; "Content-Type" = "application/json" } `
+  -Body '{
+    "ticketText":"*** TEST LAI ***\nIMPRESION OK\n",
+    "printConfig":{"ticketWidthMm":58,"copies":1,"printerName":""}
+  }'
+```
+
+También podés usar:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\LAI Print Agent\scripts\validate_agent.ps1" -ApiKey "TU_API_KEY"
+```
+
+## Diagnóstico rápido si algo falla
+
+1. Ver logs:
+   - `C:\Program Files\LAI Print Agent\logs\agent.log`
+   - `C:\Program Files\LAI Print Agent\logs\agent-stderr.log`
+2. Reiniciar agente:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\LAI Print Agent\scripts\stop_agent.ps1"
+powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\LAI Print Agent\scripts\start_agent.ps1"
+```
+
+3. Revisar tarea programada (si autostart): `LAI-Print-Agent`.
+
+## Integración con PHP (`/lai/`)
+
+Desde el sistema web (servidor online, por ejemplo `https://tu-dominio.com/lai/`) enviar tickets a:
+
+- `http://127.0.0.1:3000/print`
+
+con header:
+
+- `x-lai-api-key: <api_key_configurada_en_esa_pc>`
+
+Si cambia el dominio, no hace falta reinstalar. Actualizalo así:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\LAI Print Agent\scripts\set_base_url.ps1" -BaseUrl "https://nuevo-dominio.com/lai/"
+```
+
+## Resumen del `.exe` (lo que pediste)
+
+El `LAI-Print-Agent-Setup.exe` permite configurar en el asistente:
+
+- dominio/URL base del sistema web,
+- impresora cuponera,
+- ancho de ticket (58/80),
+- API key local,
+- auto inicio del agente.

--- a/lai/local-print-agent-node/agent.js
+++ b/lai/local-print-agent-node/agent.js
@@ -167,11 +167,12 @@ function runPrintJob(payload) {
 function startServer() {
   const config = loadConfig();
   const host = config.server?.host || '127.0.0.1';
-  const port = Number(config.server?.port || 5399);
+  const port = Number(config.server?.port || 3000);
   const apiKey = String(config.server?.apiKey || '');
 
   const server = http.createServer(async (req, res) => {
-    const url = new URL(req.url, `http://${req.headers.host}`);
+    const reqHost = req.headers.host || `${host}:${port}`;
+    const url = new URL(req.url, `http://${reqHost}`);
 
     if (req.method === 'GET' && url.pathname === '/health') {
       return jsonResponse(res, 200, { status: 'ok', host, port });
@@ -200,6 +201,11 @@ function startServer() {
         }
 
         const finalConfig = normalizePrintConfig(config, body.printConfig || {});
+        writeLog('INFO', 'Solicitud de impresión recibida', {
+          printerName: finalConfig.printerName || 'default',
+          copies: finalConfig.copies,
+          ticketWidthMm: finalConfig.ticketWidthMm,
+        });
         const normalizedText = normalizeText(rawText, finalConfig.charsPerLine);
 
         const printPayload = {
@@ -229,7 +235,7 @@ function startServer() {
   });
 
   server.listen(port, host, () => {
-    writeLog('INFO', 'Agente iniciado', { host, port });
+    writeLog('INFO', 'Agente iniciado', { host, port, configPath: CONFIG_PATH, printScript: PRINT_SCRIPT_PATH });
     // eslint-disable-next-line no-console
     console.log(`LAI Local Print Agent escuchando en http://${host}:${port}`);
   });

--- a/lai/local-print-agent-node/config.example.json
+++ b/lai/local-print-agent-node/config.example.json
@@ -1,8 +1,11 @@
 {
   "server": {
     "host": "127.0.0.1",
-    "port": 5399,
+    "port": 3000,
     "apiKey": "CAMBIAR_ESTA_CLAVE_LOCAL"
+  },
+  "integration": {
+    "baseUrl": ""
   },
   "printDefaults": {
     "printerName": "",

--- a/lai/local-print-agent-node/installer/LAIPrintAgent.iss
+++ b/lai/local-print-agent-node/installer/LAIPrintAgent.iss
@@ -1,13 +1,14 @@
 #define MyAppName "LAI Local Print Agent"
-#define MyAppVersion "1.0.0"
+#define MyAppVersion "1.0.1"
 #define MyAppPublisher "LAI"
+#define MyAppCreatorEmail "facundoj.romero@gmail.com"
 #define MyAppExeName "run-agent.cmd"
 
 [Setup]
 AppId={{A13D9C7C-9D4A-4C5A-917C-9B2B6E0A5A31}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
-AppPublisher={#MyAppPublisher}
+AppPublisher={#MyAppPublisher} - {#MyAppCreatorEmail}
 DefaultDirName={autopf}\LAI Print Agent
 DefaultGroupName=LAI Print Agent
 OutputDir=.
@@ -33,19 +34,28 @@ Source: "..\run-agent.cmd"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\scripts\print_ticket.ps1"; DestDir: "{app}\scripts"; Flags: ignoreversion
 Source: "..\scripts\install_agent.ps1"; DestDir: "{app}\scripts"; Flags: ignoreversion
 Source: "..\scripts\uninstall_agent.ps1"; DestDir: "{app}\scripts"; Flags: ignoreversion
+Source: "..\scripts\start_agent.ps1"; DestDir: "{app}\scripts"; Flags: ignoreversion
+Source: "..\scripts\stop_agent.ps1"; DestDir: "{app}\scripts"; Flags: ignoreversion
+Source: "..\scripts\validate_agent.ps1"; DestDir: "{app}\scripts"; Flags: ignoreversion
+Source: "..\scripts\set_base_url.ps1"; DestDir: "{app}\scripts"; Flags: ignoreversion
 Source: "..\runtime\*"; DestDir: "{app}\runtime"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Run]
-Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\install_agent.ps1"" -InstallDir ""{app}"" -ServerHost ""127.0.0.1"" -ServerPort 5399 -ApiKey ""{code:GetApiKey}"" -PrinterName ""{code:GetPrinterName}"" -TicketWidthMm {code:GetTicketWidth} {code:GetAutoStartFlag}"; Flags: runhidden waituntilterminated
-Filename: "{app}\run-agent.cmd"; Description: "Iniciar ahora el agente"; Flags: nowait postinstall skipifsilent
+Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\install_agent.ps1"" -InstallDir ""{app}"" -ServerHost ""127.0.0.1"" -ServerPort 3000 -ApiKey ""{code:GetApiKey}"" -BaseUrl ""{code:GetBaseUrl}"" -PrinterName ""{code:GetPrinterName}"" -TicketWidthMm {code:GetTicketWidth} {code:GetAutoStartFlag}"; Flags: runhidden waituntilterminated
 
 [UninstallRun]
-Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\uninstall_agent.ps1"""; Flags: runhidden
+Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\uninstall_agent.ps1"" -InstallDir ""{app}"""; Flags: runhidden
 
 [Code]
 var
+  ServerPage: TInputQueryWizardPage;
   ApiKeyPage: TInputQueryWizardPage;
   PrintPage: TInputQueryWizardPage;
+
+function GetBaseUrl(Value: string): string;
+begin
+  Result := ServerPage.Values[0];
+end;
 
 function GetApiKey(Value: string): string;
 begin
@@ -70,10 +80,61 @@ begin
     Result := '';
 end;
 
+function IsValidHttpUrl(const Value: string): Boolean;
+var
+  LowerValue: string;
+begin
+  LowerValue := LowerCase(Trim(Value));
+  Result := (LowerValue = '') or Pos('http://', LowerValue) = 1 or Pos('https://', LowerValue) = 1;
+end;
+
+function IsValidTicketWidth(const Value: string): Boolean;
+begin
+  Result := (Trim(Value) = '58') or (Trim(Value) = '80');
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+
+  if CurPageID = ServerPage.ID then
+  begin
+    if not IsValidHttpUrl(ServerPage.Values[0]) then
+    begin
+      MsgBox('La URL base debe comenzar con http:// o https://, o quedar vacía.', mbError, MB_OK);
+      Result := False;
+      exit;
+    end;
+  end;
+
+  if CurPageID = PrintPage.ID then
+  begin
+    if not IsValidTicketWidth(PrintPage.Values[1]) then
+    begin
+      MsgBox('El ancho del ticket debe ser 58 o 80.', mbError, MB_OK);
+      Result := False;
+      exit;
+    end;
+  end;
+end;
+
 procedure InitializeWizard;
 begin
-  ApiKeyPage := CreateInputQueryPage(
+  WizardForm.WelcomeLabel2.Caption :=
+    WizardForm.WelcomeLabel2.Caption + #13#10 + #13#10 +
+    'Creador: {#MyAppCreatorEmail}';
+
+  ServerPage := CreateInputQueryPage(
     wpSelectTasks,
+    'Integración con servidor web',
+    'Definí la URL de tu sistema web (puede cambiar luego)',
+    'Este valor se guarda en config.json y es editable en cualquier momento.'
+  );
+  ServerPage.Add('URL base del sistema web (https://...):', False);
+  ServerPage.Values[0] := '';
+
+  ApiKeyPage := CreateInputQueryPage(
+    ServerPage.ID,
     'Configuración local del agente',
     'Definí credenciales y parámetros base',
     'Estos valores se guardan en config.json para esta PC.'

--- a/lai/local-print-agent-node/run-agent.cmd
+++ b/lai/local-print-agent-node/run-agent.cmd
@@ -3,8 +3,12 @@ setlocal
 set "BASE_DIR=%~dp0"
 set "NODE_EXE=%BASE_DIR%runtime\node.exe"
 
+pushd "%BASE_DIR%"
 if exist "%NODE_EXE%" (
   "%NODE_EXE%" "%BASE_DIR%agent.js"
 ) else (
   node "%BASE_DIR%agent.js"
 )
+set "EXIT_CODE=%ERRORLEVEL%"
+popd
+exit /b %EXIT_CODE%

--- a/lai/local-print-agent-node/scripts/build_installer.ps1
+++ b/lai/local-print-agent-node/scripts/build_installer.ps1
@@ -1,8 +1,34 @@
 param(
-  [string]$InnoSetupCompiler = 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
+  [string]$InnoSetupCompiler = ''
 )
 
 $ErrorActionPreference = 'Stop'
+
+function Resolve-IsccPath([string]$PreferredPath) {
+  if (-not [string]::IsNullOrWhiteSpace($PreferredPath) -and (Test-Path -Path $PreferredPath)) {
+    return $PreferredPath
+  }
+
+  $fromCommand = Get-Command ISCC.exe -ErrorAction SilentlyContinue
+  if ($fromCommand) {
+    return $fromCommand.Source
+  }
+
+  $candidates = @(
+    'C:\Program Files (x86)\Inno Setup 6\ISCC.exe',
+    'C:\Program Files\Inno Setup 6\ISCC.exe',
+    'C:\Program Files (x86)\Inno Setup 5\ISCC.exe',
+    'C:\Program Files\Inno Setup 5\ISCC.exe'
+  )
+
+  foreach ($candidate in $candidates) {
+    if (Test-Path -Path $candidate) {
+      return $candidate
+    }
+  }
+
+  return $null
+}
 
 $rootDir = Split-Path -Path $PSScriptRoot -Parent
 $issPath = Join-Path $rootDir 'installer\LAIPrintAgent.iss'
@@ -11,16 +37,17 @@ if (-not (Test-Path -Path $issPath)) {
   throw "No existe el .iss: $issPath"
 }
 
-if (-not (Test-Path -Path $InnoSetupCompiler)) {
-  throw "No existe ISCC.exe en '$InnoSetupCompiler'. Instalá Inno Setup 6 o pasá -InnoSetupCompiler."
+$resolvedIscc = Resolve-IsccPath -PreferredPath $InnoSetupCompiler
+if (-not $resolvedIscc) {
+  throw "ISCC.exe not found. Install Inno Setup (v6 recommended) or pass -InnoSetupCompiler with full path."
 }
 
-Write-Output "[LAI-BUILD] Compilando instalador con $InnoSetupCompiler"
-& "$InnoSetupCompiler" "$issPath"
+Write-Output "[LAI-BUILD] Compiling installer with $resolvedIscc"
+& "$resolvedIscc" "$issPath"
 
 $outputExe = Join-Path (Join-Path $rootDir 'installer') 'LAI-Print-Agent-Setup.exe'
 if (Test-Path -Path $outputExe) {
-  Write-Output "[LAI-BUILD] EXE generado: $outputExe"
+  Write-Output "[LAI-BUILD] EXE generated: $outputExe"
 } else {
-  Write-Output "[LAI-BUILD] Compilación terminada. Revisá output en carpeta installer."
+  Write-Output "[LAI-BUILD] Compilation finished. Check output in installer folder."
 }

--- a/lai/local-print-agent-node/scripts/build_installer.ps1
+++ b/lai/local-print-agent-node/scripts/build_installer.ps1
@@ -17,8 +17,10 @@ function Resolve-IsccPath([string]$PreferredPath) {
   $candidates = @(
     'C:\Program Files (x86)\Inno Setup 6\ISCC.exe',
     'C:\Program Files\Inno Setup 6\ISCC.exe',
+    (Join-Path $env:LOCALAPPDATA 'Programs\Inno Setup 6\ISCC.exe'),
     'C:\Program Files (x86)\Inno Setup 5\ISCC.exe',
-    'C:\Program Files\Inno Setup 5\ISCC.exe'
+    'C:\Program Files\Inno Setup 5\ISCC.exe',
+    (Join-Path $env:LOCALAPPDATA 'Programs\Inno Setup 5\ISCC.exe')
   )
 
   foreach ($candidate in $candidates) {

--- a/lai/local-print-agent-node/scripts/build_installer.ps1
+++ b/lai/local-print-agent-node/scripts/build_installer.ps1
@@ -1,0 +1,26 @@
+param(
+  [string]$InnoSetupCompiler = 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$rootDir = Split-Path -Path $PSScriptRoot -Parent
+$issPath = Join-Path $rootDir 'installer\LAIPrintAgent.iss'
+
+if (-not (Test-Path -Path $issPath)) {
+  throw "No existe el .iss: $issPath"
+}
+
+if (-not (Test-Path -Path $InnoSetupCompiler)) {
+  throw "No existe ISCC.exe en '$InnoSetupCompiler'. Instalá Inno Setup 6 o pasá -InnoSetupCompiler."
+}
+
+Write-Output "[LAI-BUILD] Compilando instalador con $InnoSetupCompiler"
+& "$InnoSetupCompiler" "$issPath"
+
+$outputExe = Join-Path (Join-Path $rootDir 'installer') 'LAI-Print-Agent-Setup.exe'
+if (Test-Path -Path $outputExe) {
+  Write-Output "[LAI-BUILD] EXE generado: $outputExe"
+} else {
+  Write-Output "[LAI-BUILD] Compilación terminada. Revisá output en carpeta installer."
+}

--- a/lai/local-print-agent-node/scripts/build_installer.ps1
+++ b/lai/local-print-agent-node/scripts/build_installer.ps1
@@ -27,6 +27,41 @@ function Resolve-IsccPath([string]$PreferredPath) {
     }
   }
 
+  $registryUninstallPaths = @(
+    'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+    'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
+    'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
+  )
+
+  foreach ($regPath in $registryUninstallPaths) {
+    $items = Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue |
+      Where-Object { $_.DisplayName -like 'Inno Setup*' }
+
+    foreach ($item in $items) {
+      if ($item.InstallLocation) {
+        $regCandidate = Join-Path $item.InstallLocation 'ISCC.exe'
+        if (Test-Path -Path $regCandidate) {
+          return $regCandidate
+        }
+      }
+    }
+  }
+
+  $wingetRoots = @(
+    (Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'),
+    (Join-Path $env:ProgramFiles 'WindowsApps')
+  )
+
+  foreach ($root in $wingetRoots) {
+    if (Test-Path -Path $root) {
+      $wingetIscc = Get-ChildItem -Path $root -Filter ISCC.exe -Recurse -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty FullName
+      if ($wingetIscc) {
+        return $wingetIscc
+      }
+    }
+  }
+
   return $null
 }
 

--- a/lai/local-print-agent-node/scripts/install_agent.ps1
+++ b/lai/local-print-agent-node/scripts/install_agent.ps1
@@ -1,8 +1,9 @@
 param(
   [string]$InstallDir = 'C:\Program Files\LAI Print Agent',
   [string]$ServerHost = '127.0.0.1',
-  [int]$ServerPort = 5399,
+  [int]$ServerPort = 3000,
   [string]$ApiKey = 'CAMBIAR_ESTA_CLAVE_LOCAL',
+  [string]$BaseUrl = '',
   [string]$PrinterName = '',
   [int]$TicketWidthMm = 58,
   [switch]$AutoStart
@@ -29,27 +30,41 @@ if (-not (Test-Path -Path $configPath)) {
 }
 
 $config = Get-Content -Path $configPath -Raw | ConvertFrom-Json
+if ($null -eq $config.server) {
+  $config | Add-Member -MemberType NoteProperty -Name server -Value ([PSCustomObject]@{})
+}
+if ($null -eq $config.printDefaults) {
+  $config | Add-Member -MemberType NoteProperty -Name printDefaults -Value ([PSCustomObject]@{})
+}
+if ($null -eq $config.integration) {
+  $config | Add-Member -MemberType NoteProperty -Name integration -Value ([PSCustomObject]@{})
+}
 
 $config.server.host = $ServerHost
 $config.server.port = $ServerPort
 $config.server.apiKey = $ApiKey
+$config.integration.baseUrl = $BaseUrl
 $config.printDefaults.printerName = $PrinterName
+if ($TicketWidthMm -ne 58 -and $TicketWidthMm -ne 80) {
+  $TicketWidthMm = 58
+}
 $config.printDefaults.ticketWidthMm = $TicketWidthMm
 
 $config | ConvertTo-Json -Depth 8 | Set-Content -Path $configPath -Encoding UTF8
 Write-Info "Config actualizada en $configPath"
 
+$startScriptPath = Join-Path $InstallDir 'scripts\start_agent.ps1'
+if (-not (Test-Path -Path $startScriptPath)) {
+  throw "No existe scripts\\start_agent.ps1 en $InstallDir"
+}
+
 if ($AutoStart) {
   $taskName = 'LAI-Print-Agent'
-  $runCmdPath = Join-Path $InstallDir 'run-agent.cmd'
-
-  if (-not (Test-Path -Path $runCmdPath)) {
-    throw "No existe run-agent.cmd en $InstallDir"
-  }
-
-  $action = New-ScheduledTaskAction -Execute $runCmdPath
+  $actionArgs = "-NoProfile -ExecutionPolicy Bypass -File `"$startScriptPath`" -InstallDir `"$InstallDir`""
+  $action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $actionArgs
   $trigger = New-ScheduledTaskTrigger -AtLogOn
-  $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Limited
+  $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+  $principal = New-ScheduledTaskPrincipal -UserId $currentUser -LogonType InteractiveToken -RunLevel Limited
   $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
 
   Register-ScheduledTask `
@@ -62,5 +77,7 @@ if ($AutoStart) {
 
   Write-Info "Tarea programada '$taskName' creada/actualizada"
 }
+
+& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $startScriptPath -InstallDir $InstallDir
 
 Write-Info 'Instalación lógica finalizada'

--- a/lai/local-print-agent-node/scripts/set_base_url.ps1
+++ b/lai/local-print-agent-node/scripts/set_base_url.ps1
@@ -1,0 +1,22 @@
+param(
+  [string]$InstallDir = 'C:\Program Files\LAI Print Agent',
+  [Parameter(Mandatory = $true)]
+  [string]$BaseUrl
+)
+
+$ErrorActionPreference = 'Stop'
+
+$configPath = Join-Path $InstallDir 'config.json'
+if (-not (Test-Path -Path $configPath)) {
+  throw "No existe config.json en: $configPath"
+}
+
+$config = Get-Content -Path $configPath -Raw | ConvertFrom-Json
+if ($null -eq $config.integration) {
+  $config | Add-Member -MemberType NoteProperty -Name integration -Value ([PSCustomObject]@{})
+}
+
+$config.integration.baseUrl = $BaseUrl
+$config | ConvertTo-Json -Depth 8 | Set-Content -Path $configPath -Encoding UTF8
+
+Write-Output "[LAI-CONFIG] baseUrl actualizada a: $BaseUrl"

--- a/lai/local-print-agent-node/scripts/start_agent.ps1
+++ b/lai/local-print-agent-node/scripts/start_agent.ps1
@@ -1,0 +1,57 @@
+param(
+  [string]$InstallDir = 'C:\Program Files\LAI Print Agent'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Info([string]$message) {
+  Write-Output "[LAI-START] $message"
+}
+
+if (-not (Test-Path -Path $InstallDir)) {
+  throw "No existe InstallDir: $InstallDir"
+}
+
+$nodeExe = Join-Path $InstallDir 'runtime\node.exe'
+$agentJs = Join-Path $InstallDir 'agent.js'
+$logDir = Join-Path $InstallDir 'logs'
+$stdoutLog = Join-Path $logDir 'agent-stdout.log'
+$stderrLog = Join-Path $logDir 'agent-stderr.log'
+
+if (-not (Test-Path -Path $nodeExe)) {
+  throw "No existe runtime\\node.exe en: $nodeExe"
+}
+
+if (-not (Test-Path -Path $agentJs)) {
+  throw "No existe agent.js en: $agentJs"
+}
+
+if (-not (Test-Path -Path $logDir)) {
+  New-Item -Path $logDir -ItemType Directory -Force | Out-Null
+}
+
+$escapedInstallDir = [Regex]::Escape($InstallDir)
+$existing = Get-CimInstance Win32_Process |
+  Where-Object {
+    $_.Name -ieq 'node.exe' -and
+    $_.CommandLine -match "$escapedInstallDir.*agent\.js"
+  }
+
+foreach ($proc in $existing) {
+  try {
+    Stop-Process -Id $proc.ProcessId -Force -ErrorAction Stop
+    Write-Info "Proceso previo detenido (PID: $($proc.ProcessId))"
+  } catch {
+    Write-Info "No se pudo detener PID $($proc.ProcessId): $($_.Exception.Message)"
+  }
+}
+
+$proc = Start-Process -FilePath $nodeExe `
+  -ArgumentList @('agent.js') `
+  -WorkingDirectory $InstallDir `
+  -WindowStyle Hidden `
+  -RedirectStandardOutput $stdoutLog `
+  -RedirectStandardError $stderrLog `
+  -PassThru
+
+Write-Info "Agente iniciado (PID: $($proc.Id))"

--- a/lai/local-print-agent-node/scripts/stop_agent.ps1
+++ b/lai/local-print-agent-node/scripts/stop_agent.ps1
@@ -1,0 +1,35 @@
+param(
+  [string]$InstallDir = 'C:\Program Files\LAI Print Agent'
+)
+
+$ErrorActionPreference = 'Continue'
+
+function Write-Info([string]$message) {
+  Write-Output "[LAI-STOP] $message"
+}
+
+if (-not (Test-Path -Path $InstallDir)) {
+  Write-Info "InstallDir no existe, se omite: $InstallDir"
+  exit 0
+}
+
+$escapedInstallDir = [Regex]::Escape($InstallDir)
+$existing = Get-CimInstance Win32_Process |
+  Where-Object {
+    $_.Name -ieq 'node.exe' -and
+    $_.CommandLine -match "$escapedInstallDir.*agent\.js"
+  }
+
+if (-not $existing) {
+  Write-Info 'No hay proceso del agente en ejecución'
+  exit 0
+}
+
+foreach ($proc in $existing) {
+  try {
+    Stop-Process -Id $proc.ProcessId -Force -ErrorAction Stop
+    Write-Info "Proceso detenido (PID: $($proc.ProcessId))"
+  } catch {
+    Write-Info "No se pudo detener PID $($proc.ProcessId): $($_.Exception.Message)"
+  }
+}

--- a/lai/local-print-agent-node/scripts/uninstall_agent.ps1
+++ b/lai/local-print-agent-node/scripts/uninstall_agent.ps1
@@ -1,5 +1,14 @@
+param(
+  [string]$InstallDir = 'C:\Program Files\LAI Print Agent'
+)
+
 $ErrorActionPreference = 'Continue'
 $taskName = 'LAI-Print-Agent'
+
+$stopScriptPath = Join-Path $InstallDir 'scripts\stop_agent.ps1'
+if (Test-Path -Path $stopScriptPath) {
+  & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $stopScriptPath -InstallDir $InstallDir
+}
 
 try {
   Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction Stop

--- a/lai/local-print-agent-node/scripts/validate_agent.ps1
+++ b/lai/local-print-agent-node/scripts/validate_agent.ps1
@@ -1,0 +1,33 @@
+param(
+  [string]$InstallDir = 'C:\Program Files\LAI Print Agent',
+  [string]$Host = '127.0.0.1',
+  [int]$Port = 3000,
+  [string]$ApiKey = 'CAMBIAR_ESTA_CLAVE_LOCAL'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$healthUrl = "http://$Host`:$Port/health"
+$printUrl = "http://$Host`:$Port/print"
+
+Write-Output "[LAI-VALIDATE] Probando health: $healthUrl"
+$health = Invoke-RestMethod -Method Get -Uri $healthUrl -TimeoutSec 8
+$health | ConvertTo-Json -Depth 4
+
+$payload = @{
+  ticketText = "*** TEST LAI ***`nFecha: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')`nImpresion de validacion"
+  printConfig = @{
+    printerName = ""
+    ticketWidthMm = 58
+    copies = 1
+  }
+} | ConvertTo-Json -Depth 5
+
+Write-Output "[LAI-VALIDATE] Enviando print de prueba: $printUrl"
+$result = Invoke-RestMethod -Method Post -Uri $printUrl -TimeoutSec 15 -Headers @{
+  'x-lai-api-key' = $ApiKey
+  'Content-Type' = 'application/json'
+} -Body $payload
+
+$result | ConvertTo-Json -Depth 4
+Write-Output '[LAI-VALIDATE] VALIDACION_OK'


### PR DESCRIPTION
### Motivation
- Provide a real Windows installer and operational flow for the LAI local print agent so it can be deployed as a single `.exe` with embedded runtime and sensible defaults. 
- Make the agent easier to manage on Windows by adding start/stop, validation and configuration update utilities and by persisting integration metadata (base URL).
- Standardize the local API port and improve logging to aid diagnostics and automated startup via Scheduled Task.

### Description
- Changed the agent default port from `5399` to `3000` in `agent.js` and `config.example.json`, and fixed URL construction using request host headers in `agent.js`.
- Added request logging in `agent.js` and extended startup log to include `CONFIG_PATH` and `PRINT_SCRIPT_PATH`; kept health (`GET /health`) and print (`POST /print`) handlers intact with API key checks.
- Added an Inno Setup installer script `installer/LAIPrintAgent.iss` with new wizard pages for `BaseUrl`, API key and ticket width validation, bumped version to `1.0.1`, and included new files and installer run/uninstall parameters.
- Added a set of Windows PowerShell helper scripts: `scripts/build_installer.ps1`, `scripts/install_agent.ps1` (improved config writing and Scheduled Task registration), `scripts/start_agent.ps1`, `scripts/stop_agent.ps1`, `scripts/validate_agent.ps1`, and `scripts/set_base_url.ps1`; updated `scripts/uninstall_agent.ps1` to stop agent before removing task.
- Added `run-agent.cmd` improvements to ensure correct working directory, preserve exit code and run embedded `runtime\node.exe` when present.
- Updated README `lai/local-print-agent-node/README.md` to document what the `.exe` installs, build instructions, install/validation flow and troubleshooting paths.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d7cbd4f08327b726275192a830f8)