### PR TITLE
Actualizar conexión DB de lai2 con nuevas credenciales

### DIFF
--- a/lai2/conexion.php
+++ b/lai2/conexion.php
@@ -1,8 +1,8 @@
 <?php
-$host = 'localhost';
-$user = 'root';
-$password = '';
-$dbname = 'sistema_venta_lai';
+$host = '127.0.0.1';
+$user = 'u385461681_lai_prueba_us';
+$password = 'Curuzu.1810';
+$dbname = 'u385461681_lai_prueba';
 
 $conn = new mysqli($host, $user, $password, $dbname);
 


### PR DESCRIPTION
### Motivation
- Actualizar la configuración central de conexión a la base de datos del cliente `lai2` para usar las nuevas credenciales provistas sin alterar la lógica de la aplicación ni el método de conexión.

### Description
- Se modificó únicamente el archivo `lai2/conexion.php`, reemplazando las variables `$host`, `$user`, `$password` y `$dbname` por los nuevos valores y manteniendo la instanciación `new mysqli($host, $user, $password, $dbname)` sin cambiar nombres de variables ni includes.
- No se agregaron nuevas conexiones, no se tocó la lógica de consultas ni se cambiaron otros archivos fuera de `lai2`.

### Testing
- Se ejecutaron búsquedas automáticas dentro de `lai2` para detectar usos de `mysqli`, `PDO` y valores antiguos, y no se encontraron otros puntos de conexión ni credenciales viejas (excluyendo `lai2/pdf/vendor`).
- Se comprobó que `lai2/conexion.php` ahora contiene las nuevas credenciales y que no quedan referencias a los valores anteriores.
- Los cambios están en la rama `codex/lai2-update-db-connection` y se preparó el PR hacia `dev`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea624568d08327a06d9d55728869c2)