### PR TITLE
dqs_0016 - Ajustes visuales: centrar evento único, renombrar RSVP y suavizar hover

### DIFF
--- a/dqs_0016/css/custom.css
+++ b/dqs_0016/css/custom.css
@@ -1,16 +1,17 @@
 
 /** ADD YOUR AWESOME CODES HERE **/
 
-/* Ajustes visuales dqs_0016: hover/activo de navegación y contacto más suaves. */
+/* Ajustes visuales dqs_0016: hover/activo de navegación y contacto más suaves.
+   Se toma como referencia el gris de style_13.css (#C0C0C0), aclarado para un efecto sutil. */
 .top-header .navbar .navbar-collapse ul li a.active,
 .top-header .navbar .navbar-collapse ul li a:hover,
 .top-header .navbar .navbar-collapse ul li a:focus {
-	background: #f3eeee;
-	color: #7f6f6b;
+	background: #eeeeee;
+	color: #6f6f6f;
 }
 
 .submit-button .btn-common:hover,
 .submit-button .btn-common:focus {
-	background-color: #f3eeee;
-	color: #7f6f6b;
+	background-color: #eeeeee;
+	color: #6f6f6f;
 }

--- a/dqs_0016/css/custom.css
+++ b/dqs_0016/css/custom.css
@@ -1,2 +1,16 @@
 
 /** ADD YOUR AWESOME CODES HERE **/
+
+/* Ajustes visuales dqs_0016: hover/activo de navegación y contacto más suaves. */
+.top-header .navbar .navbar-collapse ul li a.active,
+.top-header .navbar .navbar-collapse ul li a:hover,
+.top-header .navbar .navbar-collapse ul li a:focus {
+	background: #f3eeee;
+	color: #7f6f6b;
+}
+
+.submit-button .btn-common:hover,
+.submit-button .btn-common:focus {
+	background-color: #f3eeee;
+	color: #7f6f6b;
+}

--- a/dqs_0016/header.php
+++ b/dqs_0016/header.php
@@ -73,7 +73,7 @@ $es_tienda =
 						<li><a class="nav-link" href="<?= $es_tienda ? '../#contact' : '#contact' ?>">Contactar</a></li>
 					<?php endif; ?>
 					
-<li><a class="nav-link open-rsvp-modal" href="#">RSVP</a></li>
+<li><a class="nav-link open-rsvp-modal" href="#">Confirmar asistencia</a></li>
 				</ul>						
 
 			</div>

--- a/dqs_0016/header.php
+++ b/dqs_0016/header.php
@@ -73,7 +73,7 @@ $es_tienda =
 						<li><a class="nav-link" href="<?= $es_tienda ? '../#contact' : '#contact' ?>">Contactar</a></li>
 					<?php endif; ?>
 					
-<li><a class="nav-link open-rsvp-modal" href="#">Confirmar asistencia</a></li>
+<li><a class="nav-link open-rsvp-modal" href="#"><span class="d-none d-xl-inline">Confirmar asistencia</span><span class="d-inline d-xl-none">Confirmar</span></a></li>
 				</ul>						
 
 			</div>

--- a/dqs_0016/index.php
+++ b/dqs_0016/index.php
@@ -385,7 +385,7 @@ $secciones = ['cronometro', 'about', 'story', 'gallery', 'events', 'wedding', 'c
                     </div>
                 </div>
             </div>
-            <div class="row">
+            <div class="row <?php echo count($info_eventos) == 1 ? 'justify-content-center' : ''; ?>">
                 <?php foreach ($info_eventos as $evento): ?>
                 <div class="col-lg-4 col-md-6 col-sm-12">
                     <div class="event-inner">

--- a/dqs_0016/index.php
+++ b/dqs_0016/index.php
@@ -257,7 +257,7 @@ $secciones = ['cronometro', 'about', 'story', 'gallery', 'events', 'wedding', 'c
             	<div class="row">
                         <div class="lbox-caption2">
                             <div class="lbox-details2">
-                                <a href="#" class="btn open-rsvp-modal">RSVP</a>
+                                <a href="#" class="btn open-rsvp-modal">Confirmar asistencia</a>
                                 <a href="tienda/" class="btn">Regalar</a>
                                 <?php if (in_array('cronometro', $secciones)): ?>
                                    <p><div class="simply-countdown simply-countdown-one"></div></p>


### PR DESCRIPTION
### Motivation
- Mejorar la presentación cuando solo hay un evento activo, aclarar el texto del menú RSVP y suavizar el color hover/activo del menú y del botón de contacto sin tocar la lógica backend ni romper responsive.

### Description
- Se agregaron cambios mínimos dentro de `dqs_0016/`: en `dqs_0016/index.php` se añade condicional `<?php echo count($info_eventos) == 1 ? 'justify-content-center' : ''; ?>` al `row` de Eventos para centrar una única card; en `dqs_0016/header.php` se cambió solo el texto visible del enlace `RSVP` a `Confirmar asistencia` manteniendo la clase `open-rsvp-modal` y el comportamiento; y en `dqs_0016/css/custom.css` se añadieron reglas para hover/activo (`#f3eeee` / `#7f6f6b`) para menú y `.submit-button .btn-common:hover` para un efecto más suave y coherente.

### Testing
- Se verificó sintaxis PHP con `php -l dqs_0016/index.php` y `php -l dqs_0016/header.php` (sin errores) y se confirmó que solo se modificaron archivos dentro de `dqs_0016/` con `git diff --name-only` (lista de archivos modificados: `dqs_0016/index.php`, `dqs_0016/header.php`, `dqs_0016/css/custom.css`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29e59b1f0c8327b18d5403ae2f8bf9)